### PR TITLE
fix: fixing status polling behavior for slower machines

### DIFF
--- a/birds_nest/pybirdai/templates/pybirdai/workflow/dashboard.html
+++ b/birds_nest/pybirdai/templates/pybirdai/workflow/dashboard.html
@@ -726,16 +726,7 @@ function pollAutomodeStatus(statusDiv, btn, targetTask) {
                 btn.disabled = false;
                 btn.textContent = 'Run Automode (from Task 3)';
             }
-        })
-        .catch(error => {
-            console.error('Automode status polling error:', error);
-            statusDiv.style.background = '#f8d7da';
-            statusDiv.style.color = '#721c24';
-            statusDiv.innerHTML = '<span style="display: inline-block; margin-right: 8px;">❌</span>Error checking automode status: ' + error.message;
-
-            btn.disabled = false;
-            btn.textContent = 'Run Automode (from Task 3)';
-        });
+        }
     }
 
     // Start polling

--- a/birds_nest/pybirdai/templates/pybirdai/workflow/dashboard.html
+++ b/birds_nest/pybirdai/templates/pybirdai/workflow/dashboard.html
@@ -726,7 +726,7 @@ function pollAutomodeStatus(statusDiv, btn, targetTask) {
                 btn.disabled = false;
                 btn.textContent = 'Run Automode (from Task 3)';
             }
-        }
+        })
     }
 
     // Start polling

--- a/birds_nest/pybirdai/workflow_views.py
+++ b/birds_nest/pybirdai/workflow_views.py
@@ -171,6 +171,8 @@ def _run_migrations_async():
 
         logger.info("Background migration process completed successfully")
 
+        time.sleep(10)
+
         os.system("pkill -f runserver")
 
     except Exception as e:
@@ -340,6 +342,8 @@ def _run_database_setup_async():
             # for i in range(restart_delay):
             #     time.sleep(1)
             #     logger.info(f"Waiting {i+1}/{restart_delay} seconds before triggering restart...")
+
+            time.sleep(10)
 
             # Create marker file FIRST (before restart) so it exists when page refreshes
             marker_path = os.path.join(base_dir, '.migration_ready_marker')


### PR DESCRIPTION
fixing status polling by:
> slowing down the end of the process (sleep)
> remove wrong catch error block which shows error without polling even if the process was running properly