### PR TITLE
Potential fix for code scanning alert no. 19: Code injection

### DIFF
--- a/birds_nest/pybirdai/views.py
+++ b/birds_nest/pybirdai/views.py
@@ -2738,7 +2738,7 @@ def return_cubelink_visualisation(request):
     if request.method == 'GET':
         cube_id = request.GET.get('cube_id', '')
         join_identifier = request.GET.get('join_identifier', '').replace("+"," ")
-        in_md = eval(request.GET.get('in_md', "false").capitalize())
+        in_md = request.GET.get('in_md', "false").lower() == 'true'
         logger.debug(f"Visualization params - cube_id: {cube_id}, join_identifier: {join_identifier}, in_md: {in_md}")
 
         if cube_id:


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-efbt/efbt/security/code-scanning/19](https://github.com/eclipse-efbt/efbt/security/code-scanning/19)

The problem occurs because user-supplied input is passed through `eval` and used to set the boolean value for `in_md`. The only permissible values should be the boolean values corresponding to whether the user intends `'true'` or `'false'`. Instead of using `eval`, which is unsafe, the code should explicitly check if the `in_md` value (case-insensitive) is `'true'`, and set `in_md` to True if so, and False otherwise.

**To fix:**  
- Replace the use of `eval(request.GET.get('in_md', "false").capitalize())` with a safer parsing construct.
- One recommended way is: `in_md = request.GET.get('in_md', 'false').lower() == 'true'`, which will result in `in_md` being True only if the input string is `'true'` (case-insensitive).
- This change should be made only in the given file and method, specifically replacing the vulnerable line.

No extra imports are necessary. No change to function arguments or returns is needed, and this change preserves existing functionality for expected values while preventing all code injection risk.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
