### PR TITLE
Potential fix for code scanning alert no. 80: Uncontrolled data used in path expression

### DIFF
--- a/birds_nest/pybirdai/utils/clone_mode/import_from_metadata_export.py
+++ b/birds_nest/pybirdai/utils/clone_mode/import_from_metadata_export.py
@@ -1018,7 +1018,12 @@ class CSVDataImporter:
 
         # Write detailed debug info to a separate file
         debug_file = f"debug_import_{csv_filename.replace('.csv', '')}.txt"
-        debug_path = os.path.join(self.results_dir, debug_file)
+        debug_path = os.path.normpath(os.path.join(self.results_dir, debug_file))
+        # Verify that the debug_path is within the results_dir (no path traversal allowed)
+        results_dir_norm = os.path.normpath(self.results_dir)
+        if not debug_path.startswith(results_dir_norm):
+            logger.error(f"Attempted debug file write outside results directory: {debug_path}")
+            raise Exception("Unsafe debug file path detected!")
         
         table_name = self._get_table_name_from_csv_filename(csv_filename)
         logger.info(f"Mapped CSV file '{csv_filename}' to table '{table_name}'")
@@ -1130,6 +1135,7 @@ class CSVDataImporter:
         
         # Write detailed debug info to file
         try:
+            # 'debug_path' is now validated to stay within 'self.results_dir'
             with open(debug_path, 'w') as f:
                 f.write(f"=== DEBUG: Import of {csv_filename} ===\n")
                 f.write(f"CSV filename: {csv_filename}\n")


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-efbt/efbt/security/code-scanning/80](https://github.com/eclipse-efbt/efbt/security/code-scanning/80)

To fix this problem, you must ensure that any filename used in constructing a path for file access cannot result in traversal outside of the intended results directory. The best fix is to (1) normalize the constructed path using `os.path.normpath` (or `os.path.realpath`) after joining the `self.results_dir` and the user-supplied filename; (2) validate that the normalized path starts with the safe base directory `self.results_dir`, aborting the operation or raising an exception if this is not the case. Optionally, you can also restrict the filename further using `werkzeug.utils.secure_filename` or similar to ensure no risky characters are present, but the root folder check is essential.

You need to edit birds_nest/pybirdai/utils/clone_mode/import_from_metadata_export.py—the construction and use of `debug_path` (lines 1020–1021 and the use at line 1133)—to ensure the normalized path is checked. Add the normalization (with `os.path.normpath`) and the safe directory check before any file I/O. If the check fails, raise an Exception and log it.

You'll need the import for `os` (already present) and can use standard Python string and path handling.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
