### PR TITLE
Potential fix for code scanning alert no. 81: Uncontrolled data used in path expression

### DIFF
--- a/birds_nest/pybirdai/utils/datapoint_test_run/run_tests.py
+++ b/birds_nest/pybirdai/utils/datapoint_test_run/run_tests.py
@@ -13,6 +13,7 @@
 
 import subprocess
 import os
+import os.path
 import json
 import argparse
 import sqlite3
@@ -24,6 +25,10 @@ import io
 
 import logging
 from pathlib import Path
+
+
+# Define safe directory for configuration files
+SAFE_CONFIG_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'tests', 'configs'))
 
 # Force UTF-8 encoding for stdout on Windows to handle Unicode characters
 if sys.platform == 'win32':
@@ -335,7 +340,39 @@ class RegulatoryTemplateTestRunner:
             logger.error(f"Failed to load config file: {str(e)}")
             return None
 
-    def run_tests_from_config(self, config_path: str, use_uv: bool=False):
+    def get_safe_config_path(self, user_config_path: str) -> str:
+        """
+        Validates and constructs a safe absolute path for a config file.
+        Returns safe config path if valid; raises ValueError if unsafe.
+        """
+        # If user_config_path is absolute, join with SAFE_CONFIG_DIR to prevent absolute escapes
+        joined_path = os.path.join(SAFE_CONFIG_DIR, os.path.basename(user_config_path))
+
+        # If input contains subdirs, preserve under SAFE_CONFIG_DIR, normalize path
+        normalized_path = os.path.normpath(os.path.join(SAFE_CONFIG_DIR, user_config_path))
+        abs_normalized_path = os.path.abspath(normalized_path)
+        # Ensure containment
+        if not abs_normalized_path.startswith(SAFE_CONFIG_DIR):
+            raise ValueError(f"Invalid config path: {user_config_path}. Access denied.")
+        return abs_normalized_path
+
+    def load_config_file(self, config_path: str) -> dict:
+        """
+        Load test configuration from a JSON file.
+
+        Args:
+            config_path: Path to config file
+
+        Returns:
+            Configuration dictionary or None if failed
+        """
+        try:
+            safe_path = self.get_safe_config_path(config_path)
+            with open(safe_path, 'r') as f:
+                return json.load(f)
+        except Exception as e:
+            logger.error(f"Failed to load config file: {str(e)}")
+            return None
         """
         Run tests based on a configuration file.
 


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-efbt/efbt/security/code-scanning/81](https://github.com/eclipse-efbt/efbt/security/code-scanning/81)

To fix this issue, we need to verify that any user-provided path (in this case, the `config_file`) is constrained to a predetermined safe directory, and that normalization is performed **before** checking containment. This is best achieved by:  
- Defining a safe root directory for configuration files (e.g. `tests/configs/`).
- Using `os.path.normpath`/`os.path.realpath` to resolve the absolute path of the user-provided value.
- Ensuring that the normalized path is within the safe root directory (not allowing escapes via `..` segments or absolute paths).
- Only opening the file if it passes this check.

All logic should be added in the code path around `load_config_file`, either inside it or before calling it. For clarity and maintainability, a helper function (e.g. `get_safe_config_path`) should be added to encapsulate this path validation logic.

This requires adding:
- The root config directory as a constant (e.g. `SAFE_CONFIG_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'tests', 'configs'))`)
- A helper function performing validation (and raising/logging an error if the input is invalid)
- Modifications to `load_config_file` to always validate/sanitize its input path before opening
- All necessary imports (just standard library modules)


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
