### PR TITLE
Potential fix for code scanning alert no. 130: Information exposure through an exception

### DIFF
--- a/birds_nest/pybirdai/lineage_views.py
+++ b/birds_nest/pybirdai/lineage_views.py
@@ -12,6 +12,7 @@ from pybirdai.models import (
     TableCreationFunction, TableCreationFunctionColumn
 )
 import json
+import logging
 
 
 def trail_lineage_viewer(request, trail_id):
@@ -640,7 +641,8 @@ def get_node_details(request, trail_id, node_type, node_id):
         return JsonResponse(details)
         
     except Exception as e:
-        return JsonResponse({'error': str(e)}, status=500)
+        logging.error("Error in get_node_details", exc_info=True)
+        return JsonResponse({'error': 'An internal error has occurred.'}, status=500)
 
 
 def trail_filtered_lineage_viewer(request, trail_id):


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-efbt/efbt/security/code-scanning/130](https://github.com/eclipse-efbt/efbt/security/code-scanning/130)

To fix the information exposure, replace the code that returns the raw exception message to the user (line 643). Instead, log the full exception information on the server for later diagnosis, and send a generic error message in the response. The logging should use Python's `logging` module (which is standard and needs no extra dependencies). Add an import for `logging` at the top of the file if it does not exist. Ensure that the exception is logged with stack trace information for debugging (using `exc_info=True`). The code change should only affect lines 643 (and potentially add an import at the top), leaving behavior otherwise unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
