### PR TITLE
Potential fix for code scanning alert no. 124: Information exposure through an exception

### DIFF
--- a/birds_nest/pybirdai/views.py
+++ b/birds_nest/pybirdai/views.py
@@ -3183,7 +3183,7 @@ def edit_member_link(request):
 
     except Exception as e:
         logger.error(f"Error editing member link: {str(e)}", exc_info=True)
-        return JsonResponse({'success': False, 'error': str(e)})
+        return JsonResponse({'success': False, 'error': 'An internal error has occurred.'})
 
 def download_member_link_template(request):
     """View function for downloading member link template."""


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-efbt/efbt/security/code-scanning/124](https://github.com/eclipse-efbt/efbt/security/code-scanning/124)

To fix the information exposure vulnerability, we should avoid returning the actual contents of the exception (`str(e)`) to the client. Instead, we should return a generic error message, such as `"An internal error has occurred"` or a similarly vague message. The actual exception details (with stack trace) should be logged server-side using the logger for developer debugging.  
The changes required are:  
- In the `except Exception as e` block of `edit_member_link`, replace the returned error string with a generic message, such as `'An internal error has occurred'`.
- Ensure that error details (with stack trace) are still logged server-side using `logger.error(..., exc_info=True)` as is currently implemented.
- No new imports are needed as logging is already set up.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
