### PR TITLE
Potential fix for code scanning alert no. 68: Information exposure through an exception

### DIFF
--- a/birds_nest/pybirdai/workflow_views.py
+++ b/birds_nest/pybirdai/workflow_views.py
@@ -3304,15 +3304,14 @@ def workflow_reset_session_partial(request):
             return redirect('pybirdai:workflow_dashboard')
 
     except Exception as e:
-        logger.error(f"Error during partial workflow session reset: {e}")
+        logger.error(f"Error during partial workflow session reset: {e}", exc_info=True)
         if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
             return JsonResponse({
                 'success': False,
-                'message': 'Failed to reset partial workflow session',
-                'error': str(e)
+                'message': 'Failed to reset partial workflow session'
             }, status=500)
         else:
-            messages.error(request, f'Failed to reset partial workflow session: {str(e)}')
+            messages.error(request, 'Failed to reset partial workflow session.')
             return redirect('pybirdai:workflow_dashboard')
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-efbt/efbt/security/code-scanning/68](https://github.com/eclipse-efbt/efbt/security/code-scanning/68)

The best practice is to return a generic error message to the user while logging the true exception details (including stack traces) internally for debugging. This means modifying the code in the `except` block to avoid exposing `str(e)` in any user-visible messages or API responses. 

- For AJAX (XHR) requests, return a generic failure message (e.g., `"Failed to reset partial workflow session"`), omitting the `'error'` field containing exception details.
- Ensure full error details are logged using the logger with `exc_info=True` to capture the stack trace for server logs.
- For standard web requests, display a generic error via `messages.error`.

Change these in the `workflow_reset_session_partial` view (lines ~3306–3316 in `birds_nest/pybirdai/workflow_views.py`). No new imports are needed, as `logger` is assumed to be available.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
